### PR TITLE
chore: change group to sccg

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
   <script class="remove">
     const respecConfig = {
-      group: "wicg",
+      group: "sccg",
       specStatus: "CG-DRAFT",
       github: {
         repoURL: "https://github.com/wicg/multicapture/",


### PR DESCRIPTION
Seems this got moved out of the WICG to the [SCCG](https://www.w3.org/community/sccg/)